### PR TITLE
send all errors after first to optional error callback

### DIFF
--- a/lib/after.js
+++ b/lib/after.js
@@ -13,13 +13,13 @@ function after(count, callback, err_cb) {
         --proxy.count;
 
         // after first error, rest are passed to err_cb
-        if (err || bail) {
+        if (err) {
             bail = true
             callback(err);
             // future error callbacks will go to error handler
             return callback = (err_cb || function() {})
         }
-        proxy.count === 0 && callback()
+        proxy.count === 0 && !bail && callback()
     }
 }
 

--- a/test/after-test.js
+++ b/test/after-test.js
@@ -96,6 +96,22 @@ test('gge', function(done) {
     next(new Error(1))
 })
 
+test('egg', function(done) {
+    function cb(err) {
+        assert.equal(err.message, 1);
+        done()
+    }
+
+    var next = after(3, cb, function(err) {
+        // should not happen
+        assert.ok(false);
+    });
+
+    next(new Error(1))
+    next()
+    next()
+})
+
 test('throws on too many calls', function(done) {
     var next = after(1, done);
     next()


### PR DESCRIPTION
- first error goes to callback, the rest are sent to an optional error
  handler. This way error information is not lost
- throw if after is called too many times
