### PR TITLE
Only include "index.js" in published NPM modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "scripts": {
     "test": "mocha --ui tdd --reporter spec test/*.js"
   },
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "mocha": "~1.8.1"
   },


### PR DESCRIPTION
Hi @kesne,

Thanks for your work with this library 🙏

I noticed that the `test` folder, `.npmignore` and `.travis.yml` are published to NPM:
![image](https://user-images.githubusercontent.com/13087421/58630151-1f0ae080-8311-11e9-82c6-f0d406d2c96c.png)

In the spirit of keeping the distributed module size small, this PR whitelists `index.js` :)

Cheers